### PR TITLE
fmt.Print the error that caused our request to fail

### DIFF
--- a/opsgenie.go
+++ b/opsgenie.go
@@ -68,7 +68,7 @@ func sendHeartbeat(h *Heartbeat) {
 	req.Header.Add("Authorization", apiKey)
 	resp, err := client.Do(req)
 	if err != nil {
-		fmt.Println("Error sending heartbeat request")
+		fmt.Printf("Error sending heartbeat request: %s\n", err.Error())
 	} else {
 		resp.Body.Close()
 	}


### PR DESCRIPTION
Notes: 
 - maybe use log instead of fmt?